### PR TITLE
fix: add semicolon to capture radius constant

### DIFF
--- a/src/SandSimulator.ts
+++ b/src/SandSimulator.ts
@@ -8,7 +8,7 @@ const KIND_AIR=int(0);
 const KIND_SAND=int(1);
 const KIND_WALL=int(2);
 const CAPTURE_POINT=vec2(0.5,0.75);
-const CAPTURE_RADIUS=float(0.2)
+const CAPTURE_RADIUS=float(0.2);
 
 // Cell構造体の定義
 const Cell = struct({


### PR DESCRIPTION
## Summary
- append missing semicolon to CAPTURE_RADIUS constant in `SandSimulator.ts`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not find declaration files for `three/tsl` and `three/webgpu`)*

------
https://chatgpt.com/codex/tasks/task_e_68947e3dd4108321987dd48fe466d463