### PR TITLE
Specify LOD for textureLoad

### DIFF
--- a/src/SandSimulator.ts
+++ b/src/SandSimulator.ts
@@ -132,7 +132,7 @@ export class SandSimulator{
         const offset = uvec2(x,y).mul(useLeftFactor).toVar("offset");
         const uvNeighbor = coord.add(offset).mod((uvec2(width,height))).toVar("uvNeighbor");
 
-        const cell = unpackCell(textureLoad(inputTexture, uvNeighbor)).toVar("cell");
+        const cell = unpackCell(textureLoad(inputTexture, uvNeighbor, int(0))).toVar("cell");
 
         cellNeighborList.element(index).assign(cell)
       });


### PR DESCRIPTION
## Summary
- pass explicit LOD of 0 when loading neighbors from input texture in compute shader

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Could not find a declaration file for module 'three/tsl')

------
https://chatgpt.com/codex/tasks/task_e_68947f0aa0808321817dd45003d5734e